### PR TITLE
Update scripts to python3

### DIFF
--- a/attributions2json.py
+++ b/attributions2json.py
@@ -5,7 +5,7 @@ import os
 import shlex
 import subprocess
 import sys
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 
 
 class Attribution():
@@ -22,7 +22,7 @@ def export_json(output, *attributions):
             file.write(jsonResult)
             file.close()
     except IOError as e:
-        print 'I/O Error: ({0}) : {1}'.format(e.errno, e.strerror)
+        print('I/O Error: ({0}) : {1}'.format(e.errno, e.strerror))
 
 
 def get_repos(input):
@@ -41,15 +41,15 @@ def get_owner_name(repo):
 
 def get_content_headers():
     headers = {}
-    if os.environ.has_key('GITHUB_ACCESS_TOKEN'):
+    if 'GITHUB_ACCESS_TOKEN' in os.environ:
         headers['Authorization'] = 'token %s' % os.environ['GITHUB_ACCESS_TOKEN']
     return headers
 
 
 def send_content_request(repo, path):
-    request = urllib2.Request('https://api.github.com/repos/%s/contents/%s' % (get_owner_name(repo), path.lstrip('/')),
+    request = urllib.request.Request('https://api.github.com/repos/%s/contents/%s' % (get_owner_name(repo), path.lstrip('/')),
         headers = get_content_headers())
-    return json.loads(urllib2.urlopen(request).read())
+    return json.loads(urllib.request.urlopen(request).read())
 
 
 def find_license_path(repo):
@@ -71,17 +71,17 @@ def get_license_text(repo):
 def validate_file(file, type):
     if type is 'input':
         if not os.path.isfile(file):
-            print 'File not found: {}'.format(file)
+            print('File not found: {}'.format(file))
             sys.exit(1)
     else:
         if not file.endswith('.json'):
-            print 'Output file must be .json'
+            print('Output file must be .json')
             sys.exit(1)
 
 
 if __name__ == '__main__':
     if len(sys.argv) != 3:
-        print 'Missing script argument: ./attributions2json [./Attribution File] [output_file.json]'
+        print('Missing script argument: ./attributions2json [./Attribution File] [output_file.json]')
         sys.exit(1)
 
     input_file = sys.argv[1]
@@ -89,8 +89,8 @@ if __name__ == '__main__':
     output_file = sys.argv[2]
     validate_file(output_file, 'output')
 
-    if not os.environ.has_key('GITHUB_ACCESS_TOKEN'):
-        print "Warning: No GITHUB_ACCESS_TOKEN environment variable configured. Expect to run into API rate limits."
+    if 'GITHUB_ACCESS_TOKEN' not in os.environ:
+        print("Warning: No GITHUB_ACCESS_TOKEN environment variable configured. Expect to run into API rate limits.")
 
     urls = get_repos(input_file)
     attributions = []
@@ -100,5 +100,5 @@ if __name__ == '__main__':
         if text:
             attributions.append(Attribution(name, text))
         else:
-            print '{}: license file not found'.format(name)
+            print('{}: license file not found'.format(name))
     export_json(output_file, *attributions)

--- a/attributions2json.py
+++ b/attributions2json.py
@@ -1,5 +1,6 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
+import base64
 import json
 import os
 import shlex
@@ -65,7 +66,8 @@ def get_license_text(repo):
     path = find_license_path(repo)
     if path:
         data = send_content_request(repo, path)
-        return data['content'].decode(data['encoding'])
+        decodedData = base64.b64decode(data['content'])
+        return decodedData.decode('utf-8')
 
 
 def validate_file(file, type):

--- a/attributions2json.py
+++ b/attributions2json.py
@@ -66,6 +66,9 @@ def get_license_text(repo):
     path = find_license_path(repo)
     if path:
         data = send_content_request(repo, path)
+        if data['encoding'] != 'base64':
+            print("Encoding of Github response was not base64")
+            sys.exit(1)
         decodedData = base64.b64decode(data['content'])
         return decodedData.decode('utf-8')
 

--- a/cartfile2json.py
+++ b/cartfile2json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import json
 import os
@@ -33,7 +33,7 @@ def exportJSON(output, *attributions):
             file.write(jsonResult)
             file.close()
     except IOError as e:
-        print 'I/O Error: ({0}) : {1}'.format(e.errno, e.strerror)
+        print('I/O Error: ({0}) : {1}'.format(e.errno, e.strerror))
 
 
 def parseCartfileFrameworks(cartfile):
@@ -51,7 +51,7 @@ def parseCartfileFrameworks(cartfile):
                     if keyValueSearch:
                         macro_buffer.update({keyValueSearch.group(1): keyValueSearch.group(2)})
                     else:
-                        print "Failed to parse Attributions macro '{}'".format(line)
+                        print("Failed to parse Attributions macro '{}'".format(line))
                 elif line.startswith('#') or line.startswith('binary'):
                     continue
                 else:
@@ -65,20 +65,20 @@ def parseCartfileFrameworks(cartfile):
                     framework = CartfileFramework(line, frameworkName, displayName, displayedForMainBundleIDs)
                     frameworks.append(framework)
     except IOError as e:
-        print 'Could not open {}'.format(cartfile)
+        print('Could not open {}'.format(cartfile))
         sys.exit(1)
     return frameworks
 
 
 def validateDirectory(directory, messageFormat):
     if not os.path.isdir(directory):
-        print messageFormat.format(directory)
+        print(messageFormat.format(directory))
         sys.exit(1)
 
 
 def validateFile(file):
     if not os.path.isfile(file):
-        print 'File not found: {}'.format(file)
+        print('File not found: {}'.format(file))
         sys.exit(1)
 
 
@@ -102,14 +102,14 @@ def buildCarthageAttributions(directory):
         try:
             licenseText = open(os.path.join(frameworkDirectory, filename)).read()
         except IOError as e:
-            print 'I/O Error: ({0}) : {1}'.format(filename, e.strerror)
+            print('I/O Error: ({0}) : {1}'.format(filename, e.strerror))
         attributions.append(Attribution(framework.displayName, framework.bundle, licenseText))
     return attributions
 
 
 if __name__ == '__main__':
     if len(sys.argv) != 3:
-        print 'Missing script argument: ./cartfile2json [Carthage directory path] [outputFile.json]'
+        print('Missing script argument: ./cartfile2json [Carthage directory path] [outputFile.json]')
         sys.exit(1)
     directory = sys.argv[1]
     outputFile = sys.argv[2]
@@ -117,5 +117,5 @@ if __name__ == '__main__':
         d = buildCarthageAttributions(directory)
         exportJSON(outputFile, *d)
     else:
-        print 'Output file must be .json'
+        print('Output file must be .json')
         sys.exit(1)


### PR DESCRIPTION
Since python2 reached EOL, all scripts should be updated to use python3 syntax.
Changes made:

- Initial conversion of all python scripts using `2to3 -w scriptname.py`
- Executed all scripts multiple times to find possible errors that weren't caught by the conversion scripts
- most of the changes are related to braces in print statements